### PR TITLE
Make hook factories RLv4 compatible

### DIFF
--- a/TBB/Modules/MTP.cs
+++ b/TBB/Modules/MTP.cs
@@ -309,7 +309,6 @@ namespace TBB
                 string agentName = instance.traitName.Substring("AlignedTo_".Length);
                 AlignedTrait aligned = new AlignedTrait { AgentName = agentName };
                 hook = aligned;
-                hook.Instance = instance;
                 return true;
             }
             hook = null;
@@ -325,7 +324,6 @@ namespace TBB
                 string agentName = instance.traitName.Substring("LoyalTo_".Length);
                 LoyalTrait loyal = new LoyalTrait { AgentName = agentName };
                 hook = loyal;
-                hook.Instance = instance;
                 return true;
             }
             hook = null;


### PR DESCRIPTION
`IHook<T>.Instance { set; }` was removed in RLv4. There's no point in setting the hook's instance inside of factories (as explained in the [docs](https://sugarbarrel.github.io/RogueLibs/docs/dev/hooks/hook-factories/#ihookfactory)).

This pull request removes all usages of the mentioned property setter, to make this mod compatible with RLv4.