### PR TITLE
Add missing ItemCategories attributes

### DIFF
--- a/TBB/Modules/Main.cs
+++ b/TBB/Modules/Main.cs
@@ -443,6 +443,7 @@ namespace TBB
             }
         }
     }
+    [ItemCategories(RogueCategories.Usable)]
     public class Thief_Bag_Low : CustomItem, IItemUsable
     {
         [RLSetup]
@@ -501,6 +502,7 @@ namespace TBB
             return true;
         }
     }
+    [ItemCategories(RogueCategories.Usable)]
     public class Thief_Bag_Avarage : CustomItem, IItemUsable
     {
         [RLSetup]
@@ -562,6 +564,7 @@ namespace TBB
             return true;
         }
     }
+    [ItemCategories(RogueCategories.Usable)]
     public class Thief_Bag_Lega : CustomItem, IItemUsable
     {
         [RLSetup]

--- a/TBB/Modules/aToI.cs
+++ b/TBB/Modules/aToI.cs
@@ -409,6 +409,7 @@ namespace TBB
 		public CustomTooltip CombineTooltip(InvItem other) => "456";
 		public CustomTooltip CombineCursorText(InvItem other) => string.Empty;
 	}
+    [ItemCategories(RogueCategories.Usable, RogueCategories.Technology, RogueCategories.Weapons, RogueCategories.NonStandardWeapons)]
 	public class NuclearBriefcase : CustomItem, IItemUsable
 	{
 		public override void SetupDetails()
@@ -429,6 +430,7 @@ namespace TBB
 			return true;
 		}
 	}
+    [ItemCategories(RogueCategories.Usable, RogueCategories.Technology, RogueCategories.Weapons, RogueCategories.NonStandardWeapons)]
 	public class OpenNuclearBriefcase : CustomItem, IItemTargetableAnywhere
 	{
 		public override void SetupDetails()
@@ -590,6 +592,7 @@ namespace TBB
 			return true;
 		}
 	}
+    [ItemCategories(RogueCategories.Technology, RogueCategories.Guns, RogueCategories.GunAccessory)]
 	public class PortableAmmoDispenser : CustomItem, IItemCombinable
 	{
 		public override void SetupDetails()
@@ -654,7 +657,7 @@ namespace TBB
 		}
 		public CustomTooltip CombineCursorText(InvItem other) => string.Empty;
 	}
-	[ItemCategories(RogueCategories.Supplies, RogueCategories.Usable)]
+	[ItemCategories(RogueCategories.Supplies, RogueCategories.Usable, RogueCategories.Food)]
 	public class Portable_Barbecue_Inactive : CustomItem, IItemCombinable
 	{
 		public override void SetupDetails()
@@ -685,7 +688,7 @@ namespace TBB
 		public CustomTooltip CombineTooltip(InvItem other) => default;
 		public CustomTooltip CombineCursorText(InvItem other) => default;
 	}
-	[ItemCategories(RogueCategories.Supplies, RogueCategories.Usable)]
+	[ItemCategories(RogueCategories.Supplies, RogueCategories.Usable, RogueCategories.Food)]
 	public class Portable_Barbecue_Active : CustomItem, IItemCombinable
 	{
 		public override void SetupDetails()


### PR DESCRIPTION
Fixes the following warnings in the console:
```
[Info   :   BepInEx] Loading [TBB 1.2.0]
[Warning: RogueLibs] Type TBB.Thief_Bag_Low does not have any ItemCategoriesAttribute!
[Warning: RogueLibs] Type TBB.Thief_Bag_Avarage does not have any ItemCategoriesAttribute!
[Warning: RogueLibs] Type TBB.Thief_Bag_Lega does not have any ItemCategoriesAttribute!
[Warning: RogueLibs] Type TBB.NuclearBriefcase does not have any ItemCategoriesAttribute!
[Warning: RogueLibs] Type TBB.OpenNuclearBriefcase does not have any ItemCategoriesAttribute!
[Warning: RogueLibs] Type TBB.PortableAmmoDispenser does not have any ItemCategoriesAttribute!
```